### PR TITLE
Add another configuration file format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "realm"
-version = "1.2.1"
+version = "1.5.0"
 dependencies = [
  "futures",
  "libc",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,13 +65,14 @@ pub struct ConfigFile {
 }
 
 /// Another config file
+/// This config file does not support port range.
 /// # Example
 /// ```json
 /// {
 ///     "relays": [
 ///         {
-///             "listen": "127.0.0.1:1080",
-///             "remote": "127.0.0.1:8080"
+///             "listen": "127.0.0.1:1080",//listening address must have address and port
+///             "remote": "127.0.0.1:8080"//remote address must have address and port
 ///         },
 ///         {
 ///             "listen": "127.0.0.1:2080",
@@ -86,11 +87,11 @@ pub struct AnotherConfigFile {
 }
 impl AnotherConfigFile {
     fn to_relay_config(&self) -> Vec<RelayConfig> {
-        let mut relay_configs = Vec::new();
-        for relay in &self.relays {
-            relay_configs.push(relay.into_relayconfig());
-        }
-        relay_configs
+        return self
+            .relays
+            .iter()
+            .map(|relay| relay.into_relayconfig())
+            .collect::<Vec<RelayConfig>>();
     }
 }
 
@@ -102,10 +103,14 @@ pub struct Relay {
 
 impl Relay {
     fn into_relayconfig(&self) -> RelayConfig {
-        let (listening_address, listening_port) =
-            self.listen.split_once(":").expect("Invalid local address");
-        let (remote_address, remote_port) =
-            self.remote.split_once(":").expect("Invalid remote address");
+        let (listening_address, listening_port) = self
+            .listen
+            .rsplit_once(":")
+            .expect("Invalid listen address");
+        let (remote_address, remote_port) = self
+            .remote
+            .rsplit_once(":")
+            .expect("Invalid remote address");
         RelayConfig::new(
             listening_address.to_string(),
             listening_port.to_string(),


### PR DESCRIPTION
Inspired by issue #41.
PS:`-c` supports two kinds of config file import.
我大概把#41里面提到的配置文件格式实现了一下,然后`-c`也支持两种配置文件导入
不过我添加的配置文件格式不支持端口段,希望有大佬可以再努力一下
第一次给开源项目做贡献有点紧张☺,写的不是很好的地方请多多包涵,
