### PR TITLE
add oci image (docker) support

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,96 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of image'
+        required: true
+        default: 'test'
+  push:
+    tags:
+      - v*
+
+name: realm Container Image Build
+
+jobs:
+  build:
+    name: Build Rust project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
+          components: rustfmt, clippy
+      
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target x86_64-unknown-linux-musl
+          
+      - uses: actions/upload-artifact@v2
+        with:
+          name: realm
+          path: target/x86_64-unknown-linux-musl/release/realm
+  
+  build-and-push:
+    name: Build and push image
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create release tmp folder
+        run: mkdir -p target/x86_64-unknown-linux-musl/release
+      - uses: actions/download-artifact@v2
+        with:
+          name: realm
+          path: target/x86_64-unknown-linux-musl/release/realm
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+          
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Echo release version
+        run: echo ${{ env.RELEASE_VERSION }}
+  
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push images with latest(debian)
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag || env.RELEASE_VERSION }}
+          
+      - name: Build and push images with alpine
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.alpine
+          push: true
+          tags: ghcr.io/${{ github.repository }}:alpine, ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag || env.RELEASE_VERSION }}-alpine
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:bullseye-slim
+
+COPY target/x86_64-unknown-linux-musl/release/realm /usr/bin
+RUN chmod +x /usr/bin/realm
+
+ENTRYPOINT ["/usr/bin/realm"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,6 @@
+FROM alpine:latest
+
+COPY target/x86_64-unknown-linux-musl/release/realm /usr/bin
+RUN chmod +x /usr/bin/realm
+
+ENTRYPOINT ["/usr/bin/realm"]

--- a/readme.container.md
+++ b/readme.container.md
@@ -1,0 +1,82 @@
+# Use realm in container
+
+We push the OCI-based image to [Github Container Registry](https://ghcr.io) with name: `ghcr.io/zhboner/realm`.
+
+These are some tag of this image:
+
+- `latest`, `v1.*` base on debian:bullseye-silm, recommend
+- `alpine`, `v1.*-alpine` base on alpine:latest
+
+## Docker
+
+```bash
+docker run -d -p 9000:9000 ghcr.io/zhboner/realm:latest -l 0.0.0.0:9000 -r 192.168.233.2:9000
+```
+
+## Docker Swarm (Docker Compose)
+
+```yaml
+# ./realm.yml
+version: '3'
+services:
+  port-9000:
+    image: ghcr.io/zhboner/realm:latest
+    ports:
+      - 9000:9000
+    command: -l 0.0.0.0:9000 -r 192.168.233.2:9000
+```
+
+```bash
+docker-compose -f ./realm.yml -p realm up -d
+```
+
+## Kubernetes
+
+```yaml
+# ./realm.yml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: realm-demo-deployment
+  labels:
+    app: realm
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: realm 
+  template:
+    metadata:
+      labels:
+        app: realm 
+    spec:
+      containers:
+      - name: realm
+        image: ghcr.io/zhboner/realm:latest
+        args:
+          - "-l 0.0.0.0:9000"
+          - "-r 192.168.233.2:9000"
+        ports:
+        - containerPort: 9000
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: realm-lb
+  namespace: default
+spec:
+  type: LoadBalancer
+  selector:
+    app: realm
+  ports:
+    - name: edge
+      port: 9000
+```

--- a/readme.container.md
+++ b/readme.container.md
@@ -55,8 +55,8 @@ spec:
       - name: realm
         image: ghcr.io/zhboner/realm:latest
         args:
-          - "-l 0.0.0.0:9000"
-          - "-r 192.168.233.2:9000"
+          - "-l=0.0.0.0:9000"
+          - "-r=192.168.233.2:9000"
         ports:
         - containerPort: 9000
         resources:

--- a/readme.md
+++ b/readme.md
@@ -22,3 +22,7 @@ An example to listen on port 30000 and forwarding traffic to example.com:12345 i
 ```
 ./realm -l 127.0.0.1:30000 -r example.com:12345
 ```
+
+## Usage in container
+
+realm can be run in a container with OCI (like Docker, Podman, Kubernetes, etc). Guide in [here](./readme.container.md).


### PR DESCRIPTION
- feat: Add Dockerfile for container image.
- feat: Add Dockerfile based on alpine for container image.
- ci: New Github Actions workflow for push container image to [`ghcr.io`](https://ghcr.io) when new tags is created or dispatch in workflow UI.
- chore: Add & Update README for container image.