### PR TITLE
feat: explicitly define nightly toolchain

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,32 @@ A simple, high performance relay server written in rust.
 
 Realm can be run in a container with OCI (like Docker, Podman, Kubernetes, etc), see guides [here](readme.container.md).
 
-## Build Guides
+## Install Guides
 
-Install **nightly** rust-toolchain with [rustup](https://rustup.rs/):
+Install rust toolchain with [rustup](https://rustup.rs/):
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Install Realm:
+
+```shell
+# Make sure you are using the latest release tag
+cargo install --git=https://github.com/zhboner/realm --tag=v2.4.2
+```
+
+You can also pass `target_cpu=native` to allow more possible optimizations:
+
+```shell
+# Make sure you are using the latest release tag
+RUSTFLAGS='-C target_cpu=native' cargo install --git=https://github.com/zhboner/realm --tag=v2.4.2
+```
+
+Or try to build by cloning this repository:
+
+```shell
+git clone https://github.com/zhboner/realm
 ```
 
 Clone this repository:
@@ -47,12 +67,6 @@ Enter the directory and build:
 
 ```shell
 cd realm && cargo build --release
-```
-
-Pass `target_cpu=native` to allow more possible optimizations:
-
-```shell
-RUSTFLAGS='-C target_cpu=native' cargo build --release
 ```
 
 ### Build Options

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This PR helps cargo to automatically install nightly toolchain if needed and build the binary against it. Also, this PR improves the installation document.