### PR TITLE
io: return bytes read/write in copy

### DIFF
--- a/realm_io/Cargo.toml
+++ b/realm_io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm_io"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["zephyr <i@zephyr.moe>"]
 description = "Realm's high performance IO collections."
 repository = "https://github.com/zhboner/realm/realm_io"

--- a/realm_io/src/buf.rs
+++ b/realm_io/src/buf.rs
@@ -1,6 +1,6 @@
-use std::io::{Result, ErrorKind};
-use std::task::{Context, Poll, ready};
+use std::io::{ErrorKind, Result};
 use std::marker::PhantomData;
+use std::task::{ready, Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -10,6 +10,7 @@ pub struct CopyBuffer<B, SR, SW> {
     pub(crate) need_flush: bool,
     pub(crate) pos: usize,
     pub(crate) cap: usize,
+    pub(crate) amt: u64,
     pub(crate) buf: B,
     _marker: PhantomData<SR>,
     __marker: PhantomData<SW>,
@@ -23,6 +24,7 @@ impl<B, SR, SW> CopyBuffer<B, SR, SW> {
             need_flush: false,
             pos: 0,
             cap: 0,
+            amt: 0,
             buf,
             _marker: PhantomData,
             __marker: PhantomData,
@@ -55,7 +57,7 @@ where
         cx: &mut Context<'_>,
         r: &mut <CopyBuffer<B, SR, SW> as AsyncIOBuf>::StreamR,
         w: &mut <CopyBuffer<B, SR, SW> as AsyncIOBuf>::StreamW,
-    ) -> Poll<Result<()>> {
+    ) -> Poll<Result<u64>> {
         loop {
             // If our buffer is empty, then we need to read some data to
             // continue.
@@ -94,6 +96,7 @@ where
                     return Poll::Ready(Err(ErrorKind::WriteZero.into()));
                 } else {
                     self.pos += i;
+                    self.amt += i as u64;
                     self.need_flush = true;
                 }
             }
@@ -107,7 +110,7 @@ where
             // data and finish the transfer.
             if self.pos == self.cap && self.read_done {
                 ready!(self.poll_flush_buf(cx, w))?;
-                return Poll::Ready(Ok(()));
+                return Poll::Ready(Ok(self.amt));
             }
         }
     }

--- a/realm_io/src/mem_copy.rs
+++ b/realm_io/src/mem_copy.rs
@@ -35,7 +35,7 @@ where
 }
 
 /// Copy data bidirectionally between two streams with userspace buffer.
-pub async fn bidi_copy<A, B>(a: &mut A, b: &mut B) -> Result<()>
+pub async fn bidi_copy<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64)>
 where
     A: AsyncRead + AsyncWrite + Unpin,
     B: AsyncRead + AsyncWrite + Unpin,

--- a/realm_io/src/zero_copy.rs
+++ b/realm_io/src/zero_copy.rs
@@ -161,7 +161,7 @@ mod tokio_net {
 }
 
 /// Copy data bidirectionally between two streams with pipe.
-pub async fn bidi_zero_copy<A, B>(a: &mut A, b: &mut B) -> Result<()>
+pub async fn bidi_zero_copy<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64)>
 where
     A: AsyncRawIO + Unpin,
     B: AsyncRawIO + Unpin,


### PR DESCRIPTION
This matches the behavior of std and Tokio copy methods, and allows doing things like reporting telemetry based on how much data is copied, for example.

The implementation follows `tokio`'s bidi copy implementation.