### PR TITLE
set default tcp keepalive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "widestring",
  "windows-sys",
  "winreg",
@@ -661,9 +661,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -1028,6 +1028,7 @@ dependencies = [
  "realm_io 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "realm_lb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "realm_syscall 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.5.5",
  "tokio",
  "trust-dns-resolver",
 ]
@@ -1087,7 +1088,7 @@ version = "0.1.7"
 dependencies = [
  "daemonize",
  "libc",
- "socket2 0.5.3",
+ "socket2 0.5.5",
 ]
 
 [[package]]
@@ -1098,7 +1099,7 @@ checksum = "8edff993b2672552f1c9afd483b8704263b0a4d7d37620e5c4a7e6760f6f9868"
 dependencies = [
  "daemonize",
  "libc",
- "socket2 0.5.3",
+ "socket2 0.5.5",
 ]
 
 [[package]]
@@ -1345,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ PROXY OPTIONS:
 TIMEOUT OPTIONS:
         --tcp-timeout <second>    override tcp timeout
         --udp-timeout <second>    override udp timeout
+        --tcp-keepalive <second>  override default tcp keepalive interval(15s)
 
 SUBCOMMANDS:
     convert    convert your legacy configuration into an advanced one
@@ -260,6 +261,7 @@ remote = "www.google.com:443"
 ├── network
 │   ├── no_tcp
 │   ├── use_udp
+│   ├── tcp_keepalive
 │   ├── tcp_timeout
 │   ├── udp_timeout
 │   ├── send_proxy
@@ -485,6 +487,14 @@ default: false
 ~~It is not recommended to enable this option, see [The Sad Story of TCP Fast Open](https://squeeze.isobar.com/2019/04/11/the-sad-story-of-tcp-fast-open/).~~
 
 ~~default: false~~
+
+#### network.tcp_keepalive: unsigned int64
+
+TCP Keepalive interval.
+
+To use system tcp keepalive interval, you need to explicitly set timeout value to 0.
+
+default: 15
 
 #### network.tcp_timeout: unsigned int
 

--- a/realm_core/Cargo.toml
+++ b/realm_core/Cargo.toml
@@ -27,6 +27,7 @@ pin-project = "1"
 trust-dns-resolver = "0.22"
 tokio = { version = "1.18", features = ["rt", "net", "time"] }
 proxy-protocol = { version = "0.5", optional = true }
+socket2 = "0.5.5"
 
 [features]
 default = []

--- a/realm_core/src/endpoint.rs
+++ b/realm_core/src/endpoint.rs
@@ -37,6 +37,7 @@ impl ProxyOpts {
 /// Connect or associate options.
 #[derive(Debug, Default, Clone)]
 pub struct ConnectOpts {
+    pub tcp_keepalive: u64,
     pub connect_timeout: usize,
     pub associate_timeout: usize,
     pub bind_address: Option<SocketAddr>,
@@ -86,6 +87,7 @@ impl Display for Endpoint {
 impl Display for ConnectOpts {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let ConnectOpts {
+            tcp_keepalive,
             connect_timeout,
             associate_timeout,
             bind_address,
@@ -126,8 +128,8 @@ impl Display for ConnectOpts {
 
         write!(
             f,
-            "connect-timeout={}s, associate-timeout={}s; ",
-            connect_timeout, associate_timeout
+            "tcp-keepalive={}s connect-timeout={}s, associate-timeout={}s; ",
+            tcp_keepalive, connect_timeout, associate_timeout
         )?;
 
         #[cfg(feature = "transport")]

--- a/realm_core/src/tcp/middle.rs
+++ b/realm_core/src/tcp/middle.rs
@@ -1,4 +1,5 @@
 use std::io::Result;
+use std::time::Duration;
 
 use tokio::net::TcpStream;
 
@@ -16,7 +17,6 @@ use super::transport;
 
 use crate::trick::Ref;
 use crate::endpoint::{RemoteAddr, ConnectOpts};
-
 #[allow(unused)]
 pub async fn connect_and_relay(
     mut local: TcpStream,
@@ -33,6 +33,8 @@ pub async fn connect_and_relay(
 
         #[cfg(feature = "balance")]
         balancer,
+
+        tcp_keepalive,
         ..
     } = conn_opts.as_ref();
 
@@ -75,6 +77,16 @@ pub async fn connect_and_relay(
 
     // connect!
     let mut remote = socket::connect(raddr, conn_opts.as_ref()).await?;
+
+    if *tcp_keepalive > 0 {
+        let sockref = socket2::SockRef::from(&remote);
+        let mut ka = socket2::TcpKeepalive::new();
+
+        ka = ka
+            .with_time(Duration::from_secs(*tcp_keepalive))
+            .with_interval(Duration::from_secs(*tcp_keepalive));
+        let _ = sockref.set_tcp_keepalive(&ka);
+    }
     log::info!("[tcp]{} => {} as {}", local.peer_addr()?, raddr, remote.peer_addr()?);
 
     // after connected

--- a/realm_core/src/tcp/mod.rs
+++ b/realm_core/src/tcp/mod.rs
@@ -14,6 +14,7 @@ mod proxy;
 mod transport;
 
 use std::io::{ErrorKind, Result};
+use std::time::Duration;
 
 use crate::trick::Ref;
 use crate::endpoint::Endpoint;
@@ -50,7 +51,15 @@ pub async fn run_tcp(endpoint: Endpoint) -> Result<()> {
 
         // ignore error
         let _ = local.set_nodelay(true);
+        if conn_opts.tcp_keepalive > 0 {
+            let sockref = socket2::SockRef::from(&local);
+            let mut ka = socket2::TcpKeepalive::new();
+            ka = ka
+                .with_time(Duration::from_secs(conn_opts.tcp_keepalive))
+                .with_interval(Duration::from_secs(conn_opts.tcp_keepalive));
 
+            let _ = sockref.set_tcp_keepalive(&ka);
+        }
         tokio::spawn(async move {
             match connect_and_relay(local, raddr, conn_opts, extra_raddrs).await {
                 Ok(..) => log::debug!("[tcp]{} => {}, finish", addr, raddr.as_ref()),

--- a/src/cmd/flag.rs
+++ b/src/cmd/flag.rs
@@ -222,6 +222,12 @@ pub fn add_global_options(app: Command) -> Command {
             .value_name("second")
             .takes_value(true)
             .display_order(1),
+        Arg::new("tcp_keepalive")
+            .long("tcp-keepalive")
+            .help("override default tcp keepalive interval(15s)")
+            .value_name("second")
+            .takes_value(true)
+            .display_order(2),
     ]);
 
     app

--- a/src/conf/net.rs
+++ b/src/conf/net.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Deserialize};
 use realm_core::endpoint::{ConnectOpts, ProxyOpts};
 
 use super::Config;
-use crate::consts::{TCP_TIMEOUT, UDP_TIMEOUT};
+use crate::consts::{TCP_KEEPALIVE, TCP_TIMEOUT, UDP_TIMEOUT};
 use crate::consts::PROXY_PROTOCOL_VERSION;
 use crate::consts::PROXY_PROTOCOL_TIMEOUT;
 
@@ -33,6 +33,10 @@ pub struct NetConf {
 
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub tcp_keepalive: Option<u64>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tcp_timeout: Option<usize>,
 
     #[serde(default)]
@@ -53,7 +57,7 @@ impl Config for NetConf {
     fn is_empty(&self) -> bool {
         crate::empty![self =>
             send_proxy, accept_proxy, send_proxy_version, accept_proxy_timeout,
-            tcp_timeout, udp_timeout
+            tcp_keepalive, tcp_timeout, udp_timeout
         ]
     }
 
@@ -69,7 +73,7 @@ impl Config for NetConf {
 
         let no_tcp = unbox!(no_tcp);
         let use_udp = unbox!(use_udp);
-
+        let tcp_keepalive = unbox!(tcp_keepalive, TCP_KEEPALIVE);
         let tcp_timeout = unbox!(tcp_timeout, TCP_TIMEOUT);
         let udp_timeout = unbox!(udp_timeout, UDP_TIMEOUT);
 
@@ -80,6 +84,7 @@ impl Config for NetConf {
         let accept_proxy_timeout = unbox!(accept_proxy_timeout, PROXY_PROTOCOL_TIMEOUT);
 
         let conn_opts = ConnectOpts {
+            tcp_keepalive: tcp_keepalive,
             connect_timeout: tcp_timeout,
             associate_timeout: udp_timeout,
 
@@ -114,6 +119,7 @@ impl Config for NetConf {
 
         rst!(self, no_tcp, other);
         rst!(self, use_udp, other);
+        rst!(self, tcp_keepalive, other);
         rst!(self, tcp_timeout, other);
         rst!(self, udp_timeout, other);
         rst!(self, send_proxy, other);
@@ -129,6 +135,7 @@ impl Config for NetConf {
 
         take!(self, no_tcp, other);
         take!(self, use_udp, other);
+        take!(self, tcp_keepalive, other);
         take!(self, tcp_timeout, other);
         take!(self, udp_timeout, other);
         take!(self, send_proxy, other);
@@ -155,6 +162,7 @@ impl Config for NetConf {
         let no_tcp = unpack!("no_tcp");
         let use_udp = unpack!("use_udp");
 
+        let tcp_keepalive = unpack!("tcp_keepalive", u64);
         let tcp_timeout = unpack!("tcp_timeout", usize);
         let udp_timeout = unpack!("udp_timeout", usize);
 
@@ -167,6 +175,7 @@ impl Config for NetConf {
         Self {
             no_tcp,
             use_udp,
+            tcp_keepalive,
             tcp_timeout,
             udp_timeout,
             send_proxy,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,6 +4,7 @@ use std::fmt::{Display, Formatter};
 pub const DEFAULT_LOG_FILE: &str = "stdout";
 
 // default timeout
+pub const TCP_KEEPALIVE: u64 = 15;
 pub const TCP_TIMEOUT: usize = 5;
 pub const UDP_TIMEOUT: usize = 30;
 


### PR DESCRIPTION
See issue (#115 )
Cargo will generate cargo.lock, it cannot be merged, so remove.