### PR TITLE
Update Cargo.toml , mimalloc speedup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # malloc
-mimalloc = { version = "0.1", optional = true }
+mimalloc = { version = "0.1", optional = true, default-features = false }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.5", optional = true }


### PR DESCRIPTION
By default this library builds mimalloc in secure mode. This means that heap allocations are encrypted, but this results in a 3% increase in overhead.

https://docs.rs/mimalloc/latest/mimalloc/

<img width="1012" alt="image" src="https://github.com/zhboner/realm/assets/145643935/d4304301-604d-4495-a17d-a684631eb585">
