### PR TITLE
feat: advanced mapping with support for splitting configurations into multiple files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -1269,6 +1270,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1628,6 +1638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +1737,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3"
 
 # runtime
 tokio = { version = "1", features = ["rt"] }
+walkdir = "2"
 
 # logger
 log = "0.4"

--- a/src/conf/mod.rs
+++ b/src/conf/mod.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::{Result, Error, ErrorKind};
-use walkdir::WalkDir;
 
+use walkdir::WalkDir;
 use clap::ArgMatches;
 use serde::{Serialize, Deserialize};
 
@@ -81,65 +81,33 @@ impl FullConf {
     }
 
     pub fn from_conf_file(file: &str) -> Self {
-        let mtd = fs::metadata(file);
-        if mtd.is_err() {
-            eprintln!("failed to open {}: {}", file, mtd.err().unwrap());
-            std::process::exit(0)
-        }
+        let mtd = fs::metadata(file).unwrap_or_else(|e| panic!("failed to open {}: {}", file, e));
 
-        let attrs = mtd.unwrap();
-        if attrs.is_file() {
-            let conf = fs::read_to_string(file).unwrap_or_else(|e| panic!("unable to open {}: {}", file, &e));
+        if mtd.is_file() {
+            let conf = fs::read_to_string(file).unwrap_or_else(|e| panic!("failed to open {}: {}", file, e));
             match Self::from_conf_str(&conf) {
                 Ok(x) => return x,
                 Err(e) => panic!("failed to parse {}: {}", file, &e),
             }
         }
 
-        let mut conf = FullConf::default();
+        let mut full_conf = FullConf::default();
         for entry in WalkDir::new(file)
             .follow_links(true)
             .into_iter()
+            .filter_entry(|e| e.file_name().to_str().is_some_and(|x| x.starts_with('.')))
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().is_file())
-            .filter(|e| {
-                e.file_name().to_string_lossy().ends_with(".toml") || e.file_name().to_string_lossy().ends_with(".json")
-            })
+            .filter(|e| e.path().extension().map_or(false, |s| s == "toml" || s == "json"))
         {
-            let mut conf_part = FullConf::default();
-            let conf_frag = fs::read_to_string(entry.path())
-                .unwrap_or_else(|e| panic!("unable to open {:#?}: {}", entry.path(), &e));
+            let conf_part = fs::read_to_string(entry.path())
+                .unwrap_or_else(|e| panic!("failed to open {}: {}", entry.path().to_string_lossy(), e));
 
-            let f_name = entry.file_name().to_string_lossy();
-            if f_name.ends_with(".json") {
-                conf_part = serde_json::from_str(conf_frag.as_str())
-                    .unwrap_or_else(|e| panic!("failed to parse {:#?}: {}", entry.path(), &e));
-            } else if f_name.ends_with(".toml") {
-                conf_part = toml::from_str(conf_frag.as_str())
-                    .unwrap_or_else(|e| panic!("failed to parse {:#?}: {}", entry.path(), &e));
-            }
-
-            if !conf_part.dns.is_empty() {
-                conf.dns.take_field(&conf_part.dns);
-            }
-            if !conf_part.log.is_empty() {
-                conf.log.take_field(&conf_part.log);
-            }
-            if !conf_part.network.is_empty() {
-                conf.network.take_field(&conf_part.network);
-            }
-            if !conf_part.endpoints.is_empty() {
-                for ep in conf_part.endpoints {
-                    conf.endpoints.push(ep);
-                }
-            }
+            let conf_part = Self::from_conf_str(&conf_part)
+                .unwrap_or_else(|e| panic!("failed to parse {}: {}", entry.path().to_string_lossy(), e));
+            full_conf.take_fields(conf_part);
         }
-
-        let conf_str = toml::to_string(&conf).unwrap();
-        match Self::from_conf_str(&conf_str.to_string()) {
-            Ok(x) => x,
-            Err(e) => panic!("failed to parse {}: {}", file, &e),
-        }
+        full_conf
     }
 
     pub fn from_conf_str(s: &str) -> Result<Self> {
@@ -169,6 +137,13 @@ impl FullConf {
                 toml_err, json_err, legacy_err
             ),
         ))
+    }
+
+    fn take_fields(&mut self, other: Self) {
+        self.log.take_field(&other.log);
+        self.dns.take_field(&other.dns);
+        self.network.take_field(&other.network);
+        self.endpoints.extend(other.endpoints);
     }
 
     pub fn add_endpoint(&mut self, endpoint: EndpointConf) -> &mut Self {


### PR DESCRIPTION
为`advanced mapping`添加“支持将配置拆分到多个配置文件”的特性

功能介绍：
1、共用原有的 `-c, --config` 命令选项，不破坏已有的行为
2、当传参为文件路径时，按照以前的逻辑进行处理
3、当传参为目录路径时，会递归查找指定目录及其子目录(未限制深度，并且会自动跟链接符号)下的`json`和`toml`配置文件(支持混合目录)
4、所有配置文件按照`advanced mapping`的配置尝试进行解析和简单的合并(无去重行为，需使用者自行处理)，解析失败则报错退出程序
5、当传参为目录路径时，且混入`LegacyConf`配置文件时，解析到此文件会报错退出程序（需使用者自行剔除）
6、当初始化 EndPoint 时，遇到在同一 IP 地址和端口重复监听时，则报错退出（需使用者自行剔除重复项）