### PR TITLE
realm-io: fix bidi_zero_copy

### DIFF
--- a/realm_io/src/linux/zero_copy.rs
+++ b/realm_io/src/linux/zero_copy.rs
@@ -43,6 +43,11 @@ impl Drop for Pipe {
     }
 }
 
+/// # Safety
+///
+/// Parameter `n` must satisfy 0 <= n <= isize::MAX
+///
+/// This constraint is enforced by the kernel's system call API, not by this wrapper function
 #[inline]
 fn splice_n(r: RawFd, w: RawFd, n: usize) -> isize {
     use libc::{loff_t, SPLICE_F_MOVE, SPLICE_F_NONBLOCK};
@@ -67,7 +72,7 @@ where
     type StreamW = SW;
 
     fn poll_read_buf(&mut self, cx: &mut Context<'_>, stream: &mut Self::StreamR) -> Poll<Result<usize>> {
-        stream.poll_read_raw(cx, || splice_n(stream.as_raw_fd(), self.buf.1, usize::MAX))
+        stream.poll_read_raw(cx, || splice_n(stream.as_raw_fd(), self.buf.1, isize::MAX as usize))
     }
 
     fn poll_write_buf(&mut self, cx: &mut Context<'_>, stream: &mut Self::StreamW) -> Poll<Result<usize>> {
@@ -88,7 +93,7 @@ where
     type StreamW = SW;
 
     fn poll_read_buf(&mut self, cx: &mut Context<'_>, stream: &mut Self::StreamR) -> Poll<Result<usize>> {
-        stream.poll_read_raw(cx, || splice_n(stream.as_raw_fd(), self.buf.1, usize::MAX))
+        stream.poll_read_raw(cx, || splice_n(stream.as_raw_fd(), self.buf.1, isize::MAX as usize))
     }
 
     fn poll_write_buf(&mut self, cx: &mut Context<'_>, stream: &mut Self::StreamW) -> Poll<Result<usize>> {


### PR DESCRIPTION
修复linux下失效的零拷贝函数bidi_zero_copy

系统调用总是失败，错误信息为：
```
splice(7, NULL, 10, NULL, 18446744073709551615, SPLICE_F_MOVE|SPLICE_F_NONBLOCK) = -1 EINVAL (Invalid argument)
```

原因是调用splice函数时，长度参数超过了内核最大限制，usize_t在强制转换成ssize_t时溢出
https://github.com/torvalds/linux/blob/c17b750b3ad9f45f2b6f7e6f7f4679844244f0b9/fs/splice.c#L1340
https://github.com/torvalds/linux/blob/c17b750b3ad9f45f2b6f7e6f7f4679844244f0b9/fs/read_write.c#L451-L457