### PR TITLE
fix: bump version to 2.9.2 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realm"
-version = "2.9.1"
+version = "2.9.2"
 authors = ["zhboner <zhboner@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
fix: bump version to 2.9.2 in Cargo.toml