### PR TITLE
feat: add passive monitoring and automatic failover

### DIFF
--- a/realm_lb/src/lib.rs
+++ b/realm_lb/src/lib.rs
@@ -2,18 +2,40 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Token(pub u8);
 
+/// Health check configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct HealthCheckConfig {
+    pub max_fails: u32,
+    pub fail_timeout_secs: u32,
+}
+
+impl Default for HealthCheckConfig {
+    fn default() -> Self {
+        Self {
+            max_fails: 2,
+            fail_timeout_secs: 120,
+        }
+    }
+}
+
 /// Load balance traits.
 pub trait Balance {
     type State;
 
     /// Constructor.
-    fn new(weights: &[u8]) -> Self;
+    fn new(weights: &[u8], config: Option<HealthCheckConfig>) -> Self;
 
     /// Get next peer.
     fn next(&self, state: &Self::State) -> Option<Token>;
 
     /// Total peers.
     fn total(&self) -> u8;
+
+    /// Record success for a peer.
+    fn on_success(&self, token: Token);
+
+    /// Record failure for a peer.
+    fn on_failure(&self, token: Token);
 }
 
 /// Iphash impl.

--- a/src/conf/legacy/mod.rs
+++ b/src/conf/legacy/mod.rs
@@ -78,6 +78,7 @@ impl From<LegacyConf> for FullConf {
                 network: Default::default(),
                 extra_remotes: Vec::new(),
                 balance: None,
+                failover: None,
             })
             .collect();
 

--- a/src/conf/net.rs
+++ b/src/conf/net.rs
@@ -59,6 +59,15 @@ pub struct NetConf {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub udp_timeout: Option<usize>,
+
+    // Health check options
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fails: Option<u32>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_timeout: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -67,6 +76,8 @@ pub struct NetInfo {
     pub conn_opts: ConnectOpts,
     pub no_tcp: bool,
     pub use_udp: bool,
+    pub max_fails: u32,
+    pub fail_timeout_ms: u32,
 }
 
 impl Config for NetConf {
@@ -77,7 +88,8 @@ impl Config for NetConf {
             no_tcp, use_udp, ipv6_only,
             send_mptcp, accept_mptcp,
             send_proxy, accept_proxy, send_proxy_version, accept_proxy_timeout,
-            tcp_keepalive, tcp_keepalive_probe, tcp_timeout, udp_timeout
+            tcp_keepalive, tcp_keepalive_probe, tcp_timeout, udp_timeout,
+            max_fails, fail_timeout
         ]
     }
 
@@ -100,6 +112,10 @@ impl Config for NetConf {
         let tcp_kpa_probe = unbox!(tcp_keepalive_probe, TCP_KEEPALIVE_PROBE);
         let tcp_timeout = unbox!(tcp_timeout, TCP_TIMEOUT);
         let udp_timeout = unbox!(udp_timeout, UDP_TIMEOUT);
+
+        // Health check options
+        let max_fails = unbox!(max_fails, 2);
+        let fail_timeout_ms = unbox!(fail_timeout, 120000);
 
         let bind_opts = BindOpts {
             ipv6_only,
@@ -144,6 +160,8 @@ impl Config for NetConf {
             conn_opts,
             no_tcp,
             use_udp,
+            max_fails,
+            fail_timeout_ms,
         }
     }
 
@@ -161,6 +179,8 @@ impl Config for NetConf {
         rst!(self, tcp_timeout, other);
         rst!(self, udp_timeout, other);
         rst!(self, send_proxy, other);
+        rst!(self, max_fails, other);
+        rst!(self, fail_timeout, other);
         rst!(self, accept_proxy, other);
         rst!(self, send_proxy_version, other);
         rst!(self, accept_proxy_timeout, other);
@@ -181,6 +201,8 @@ impl Config for NetConf {
         take!(self, tcp_timeout, other);
         take!(self, udp_timeout, other);
         take!(self, send_proxy, other);
+        take!(self, max_fails, other);
+        take!(self, fail_timeout, other);
         take!(self, accept_proxy, other);
         take!(self, send_proxy_version, other);
         take!(self, accept_proxy_timeout, other);
@@ -234,6 +256,8 @@ impl Config for NetConf {
             accept_proxy,
             send_proxy_version,
             accept_proxy_timeout,
+            max_fails: None,
+            fail_timeout: None,
         }
     }
 }


### PR DESCRIPTION
相关 Issue：  
- https://github.com/zhboner/realm/issues/145  
- https://github.com/zhboner/realm/issues/113  
- https://github.com/zhboner/realm/issues/98  
- https://github.com/zhboner/realm/issues/82  
## passive-health-checks-and-automatic-failover
功能主要在 `realm_lb` 模块中实现，日志部分复用已有的 `socket.rs` 日志机制

新增三项配置参数：`max_fails`、`fail_timeout`、`failover`，用于控制被动检查和故障转移行为

为负载均衡器添加两个回调接口：`on_success` 和 `on_failure`
   ```rust
   balancer.on_success(balance_token);
   balancer.on_failure(balance_token);
```

最小配置示例（仅需多一行failover = true）
```toml
[network]
no_tcp = false
use_udp = true

[[endpoints]]
listen = "0.0.0.0:9001"
remote = "127.0.0.1:20000"
extra_remotes = ["127.0.0.1:20001", "127.0.0.1:20002"]
balance = "iphash: 9, 1, 1"
failover = true
```
可选的两个全局参数
```toml
[network]
max_fails = 2
fail_timeout = 120000
```

配置机制与 Realm 原有结构保持一致，可在全局 [network] 设置，也可在 [endpoints.network] 中单独覆盖，实现更精细化的控制

### 参数说明

- max_fails：最大失败次数。默认 2 次失败后标记为故障并暂时移出
- fail_timeout：冷却期。默认 120000 毫秒（即 120 秒）。在冷却期结束后会重新探测该后端是否恢复

### 故障转移触发逻辑
- 默认 failover = false，需手动开启
- 启用负载均衡后再配置 failover = true 方可生效

### 负载均衡-被动检查-故障转移机制流程

- 轮询模式(roundrobin)
正常:无变化
故障:两次失败→标记失败→冷却期跳过故障后端
恢复:间隔冷却期探测→探测成功恢复→低权重渐进恢复减少误判卡顿
全部故障:复用轮询负载均衡算法

- 一致性哈希模式(iphash)
正常:无变化
故障:两次失败→标记失败→去重沿哈希环线性探测（即使故障也不破坏原权重特性）选择健康后端
恢复:间隔冷却期探测→探测成功恢复初始后端
全部故障:复用iphash负载均衡算法

### 其他说明
不破坏原 Realm 的hook机制，依旧保持优先级hook > balancer

本次修改主要集中在 realm_lb 模块

CI 检查中出现的错误信息（no method named 'on_success' found for &Balancer 等）来自依赖版本差异，当前仓库尚未包含 realm_lb 中的（on_success() / on_failure()）接口
测试分支中，通过临时调整 realm_lb/Cargo.toml 以使用本地路径依赖（path），已完成编译与打包验证，确认逻辑可正常工作。
https://github.com/zywe03/realm/tree/release-test

---

# English Summary

Related Issues:  
- https://github.com/zhboner/realm/issues/145  
- https://github.com/zhboner/realm/issues/113  
- https://github.com/zhboner/realm/issues/98  
- https://github.com/zhboner/realm/issues/82  

## Passive Health Checks and Automatic Failover

This feature is primarily implemented in the `realm_lb` module, with logging functionality reusing the existing `socket.rs` logging mechanism.

Three new configuration parameters have been added: `max_fails`, `fail_timeout`, and `failover` to control passive health checking and failover behavior.

Two callback interfaces have been added to the load balancer: `on_success` and `on_failure`
```rust
balancer.on_success(balance_token);
balancer.on_failure(balance_token);
```

Minimal configuration example (just add one line: `failover = true`)
```toml
[network]
no_tcp = false
use_udp = true

[[endpoints]]
listen = "0.0.0.0:9001"
remote = "127.0.0.1:20000"
extra_remotes = ["127.0.0.1:20001", "127.0.0.1:20002"]
balance = "iphash: 9, 1, 1"
failover = true
```

Optional global parameters
```toml
[network]
max_fails = 2
fail_timeout = 120000
```

The configuration mechanism maintains consistency with realm's existing structure. Parameters can be set globally in `[network]` or overridden individually in `[endpoints.network]` for more granular control.

### Parameter Description

- `max_fails`: Maximum number of failures. Default is 2 failures before marking as unhealthy and temporarily removing from rotation
- `fail_timeout`: Cooldown period. Default is 120000 milliseconds (120 seconds). After the cooldown period, the backend will be probed again to check if it has recovered

### Failover Trigger Logic
- Default `failover = false`, requires manual enablement
- Must configure `failover = true` after enabling load balancing for it to take effect

### Load Balancing - Passive Health Check - Failover Mechanism Flow

- **Round Robin Mode (roundrobin)**
  - Normal: No changes
  - Failure: Two failures → Mark as failed → Skip failed backend during cooldown period
  - Recovery: Probe at cooldown intervals → Restore on successful probe → Gradual low-weight recovery to reduce false positive stuttering
  - All failed: Reuse round-robin load balancing algorithm

- **Consistent Hash Mode (iphash)**
  - Normal: No changes
  - Failure: Two failures → Mark as failed → Deduplicate and linearly probe along hash ring (maintains original weight characteristics even when failed) to select healthy backend
  - Recovery: Probe at cooldown intervals → Restore original backend on successful probe
  - All failed: Reuse iphash load balancing algorithm

### Additional Notes
- Does not break the original Realm hook mechanism; the priority order hook > balancer is preserved.
This PR mainly focuses on the realm_lb module.
The errors in CI (e.g., "no method named 'on_success' found for &Balancer") are due to dependency version differences—the current repo doesn't yet include the (on_success() / on_failure()) interfaces in realm_lb.
In the test branch, I've temporarily modified realm_lb/Cargo.toml to use a local path dependency, and verified that compilation and packaging work correctly.

https://github.com/zywe03/realm/tree/release-test