### PR TITLE
fix(ip_hash): 用回绕运算替代 unchecked 算术，避免溢出未定义行为

### DIFF
--- a/realm_lb/src/ip_hash.rs
+++ b/realm_lb/src/ip_hash.rs
@@ -82,13 +82,13 @@ mod chash {
 
     macro_rules! c_add {
         ($a:expr, $b:expr) => {
-            unsafe { $a.unchecked_add($b) }
+            $a.wrapping_add($b)
         };
     }
 
     macro_rules! c_mul {
         ($a:expr, $b:expr) => {
-            unsafe { $a.unchecked_mul($b) }
+            $a.wrapping_mul($b)
         };
     }
 


### PR DESCRIPTION
将 c_add/c_mul 宏中的 unsafe unchecked_add/unchecked_mul 替换为安全的 wrapping_add/wrapping_mul，在保持一致性哈希
环绕语义的同时消除溢出引发的未定义行为风险。

修复一处debug环境panic。