### PR TITLE
ci: use zig cc for linux-gnu targets to pin glibc 2.17

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -4,6 +4,22 @@ pre-build = [
   "apt install -y clang libclang-dev nasm"
 ]
 
+[target.x86_64-unknown-linux-gnu]
+zig = "2.17"
+pre-build = [
+  "apt update",
+  "DEBIAN_FRONTEND=noninteractive apt install -y clang libclang-dev nasm curl xz-utils",
+  "curl -sSfL https://github.com/rust-cross/cargo-zigbuild/releases/latest/download/cargo-zigbuild-installer.sh | CARGO_HOME=/usr/local sh"
+]
+
+[target.aarch64-unknown-linux-gnu]
+zig = "2.17"
+pre-build = [
+  "apt update",
+  "DEBIAN_FRONTEND=noninteractive apt install -y clang libclang-dev nasm curl xz-utils",
+  "curl -sSfL https://github.com/rust-cross/cargo-zigbuild/releases/latest/download/cargo-zigbuild-installer.sh | CARGO_HOME=/usr/local sh"
+]
+
 [target.mips-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/mips-unknown-linux-gnu:main"
 build-std = ["core", "std", "alloc", "proc_macro", "panic_abort"]


### PR DESCRIPTION
Fixes #173

按 #173 的思路用 `zig = "2.17"` 钉住 glibc，保留 `:main` 镜像的最新工具链。

### Problem

v2.9.5 的 CI 所使用的交叉编译工具链 [cross-rs](https://github.com/cross-rs/cross) 的 Docker 镜像基座从 **Ubuntu 20.04 升级到了 Ubuntu 24.04**,这直接将运行时的最低 glibc 门槛从 v2.9.4 的 2.30 抬高到了 **2.38**。在 glibc < 2.38 的系统（如 Debian 12/glibc 2.36、Ubuntu 22.04/glibc 2.35）上运行时，就会报错 `GLIBC_2.38 not found`。

### Fix

`Cross.toml` 为两个 gnu 目标启用 zig（cross 官方 `target.TARGET.zig` 配置，`CommandVariant::Zig` → cargo-zigbuild），glibc 钉在 2.17：

```toml
[target.x86_64-unknown-linux-gnu]
zig = "2.17"
...
```

- fork 上完整跑通 release 流程，ci通过